### PR TITLE
Sequencestorage refactor

### DIFF
--- a/include/App.hpp
+++ b/include/App.hpp
@@ -50,7 +50,7 @@ private:
     Vec2f                       _initPlayerPos;
 
     size_t                      _frameId;
-    size_t                      _batchId;
+    size_t                      _batchEntryId;
     bool                        _newPatchReady;
 
     ModelProto                  _model;

--- a/include/Image.hpp
+++ b/include/Image.hpp
@@ -11,6 +11,8 @@
 #pragma once
 
 
+#include "Utils.hpp"
+
 #include <cstdint>
 #include <vector>
 
@@ -25,17 +27,24 @@ inline int getImageFormatNChannels(ImageFormat imageFormat);
 template <typename T_Data>
 class Image {
 public:
-    Image(int width=0, int height=0, ImageFormat format=ImageFormat::BGRA, const T_Data* data=nullptr);
-    Image(const Image& image) = default;
-    Image(Image&& image) noexcept = default;
-    Image& operator=(const Image& image) = default;
-    Image& operator=(Image&& image) noexcept = default;
+    // If data is nullptr, internal buffer will be used. Otherwise, the buffer pointed by data will
+    // be utilized as the pixel data buffer. Ownership will not be transferred.
+    Image(int width=0, int height=0, ImageFormat format=ImageFormat::BGRA, T_Data* data=nullptr);
+    Image(const Image<T_Data>& other);
+    Image(Image&&) noexcept = default;
+    Image& operator=(const Image<T_Data>& other);
+    Image& operator=(Image&&) noexcept = default;
 
     int width() const noexcept;
     int height() const noexcept;
     const ImageFormat& format() const noexcept;
     const T_Data* data() const noexcept;
 
+    // Set pixel data (will read width * height * nchannels * sizeof(T_Data) bytes from data)
+    void copyFrom(const T_Data* data);
+
+    template <typename T_DataOther>
+    friend class Image;
     template <typename T_DataSrc, typename T_DataDest>
     friend void convertImage(const Image<T_DataSrc>&, Image<T_DataDest>&);
 
@@ -43,7 +52,13 @@ private:
     int                 _width;
     int                 _height;
     ImageFormat         _format;
-    std::vector<T_Data> _data;
+
+    T_Data*             _data;
+    size_t              _nElements;
+    std::vector<T_Data> _buffer;
+
+    template <typename T_DataOther>
+    void copyParamsFrom(const Image<T_DataOther>& other);
 };
 
 

--- a/include/ModelProto.hpp
+++ b/include/ModelProto.hpp
@@ -31,7 +31,7 @@ public:
     ModelProto& operator=(const ModelProto&) = delete;
     ModelProto& operator=(ModelProto&&) = delete;
 
-    void train(const SequenceStorage& storage);
+    void train(SequenceStorage&& storage);
     void trainAsync(SequenceStorage&& storage);
     bool trainingFinished() const noexcept;
     void waitForTrainingFinish();

--- a/include/ModelProto.hpp
+++ b/include/ModelProto.hpp
@@ -32,7 +32,7 @@ public:
     ModelProto& operator=(ModelProto&&) = delete;
 
     void train(const SequenceStorage& storage);
-    void trainAsync(const SequenceStorage& storage);
+    void trainAsync(SequenceStorage&& storage);
     bool trainingFinished() const noexcept;
     void waitForTrainingFinish();
 

--- a/include/SequenceStorage.hpp
+++ b/include/SequenceStorage.hpp
@@ -16,39 +16,79 @@
 
 class SequenceStorage {
 public:
-    struct Entry {
-        gvizdoom::Action    action;
-        Image<uint8_t>      frame;          // frame after the action
-        double              reward  {0.0};  // reward after the action
+    struct Settings {
+        uint32_t    batchSize;
+        std::size_t length;     // max sequence length
+        uint32_t    frameWidth;
+        uint32_t    frameHeight;
+        ImageFormat frameFormat;
     };
 
     class BatchHandle {
     public:
-        Entry& operator[](std::size_t id);
-        const Entry& operator[](std::size_t id) const noexcept;
+        gvizdoom::Action* const actions;
+        Image<float>* const     frames;
+        double* const           rewards;
 
         friend class SequenceStorage;
 
     private:
-        BatchHandle();
-        Entry*          _entry;
-        const Entry*    _cEntry;
+        BatchHandle(
+            gvizdoom::Action* actions,
+            Image<float>* frames,
+            double* rewards);
     };
 
-    SequenceStorage(std::size_t batchSize, std::size_t length=0);
-    SequenceStorage(const SequenceStorage&) = default;
-    SequenceStorage(SequenceStorage&&) = default;
-    SequenceStorage& operator=(const SequenceStorage&) = default;
-    SequenceStorage& operator=(SequenceStorage&&) = default;
+    class ConstBatchHandle {
+    public:
+        const gvizdoom::Action* const   actions;
+        const Image<float>* const       frames;
+        const double* const             rewards;
+
+        friend class SequenceStorage;
+
+    private:
+        ConstBatchHandle(
+            const gvizdoom::Action* actions,
+            const Image<float>* frames,
+            const double* rewards);
+    };
+
+
+    SequenceStorage(const Settings& settings);
+    SequenceStorage(const SequenceStorage& other);
+    SequenceStorage(SequenceStorage&& other) noexcept;
+    SequenceStorage& operator=(const SequenceStorage& other);
+    SequenceStorage& operator=(SequenceStorage&& other) noexcept;
 
     // Access a batch
-    BatchHandle& operator[](std::size_t id);
-    const BatchHandle operator[](std::size_t id) const noexcept;
+    BatchHandle operator[](std::size_t id);
+    ConstBatchHandle operator[](std::size_t id) const noexcept;
 
-    size_t size() const;
+    const Settings& settings() const noexcept;
 
 private:
-    std::size_t         _batchSize;
-    std::vector<Entry>  _data;
-    BatchHandle         _batchHandle;
+    Settings                        _settings;
+
+    // Sequence data vectors
+    std::vector<gvizdoom::Action>   _actions;
+    std::vector<Image<float>>       _frames;
+    std::vector<float>              _frameData; // pixel data storage for _frames
+    std::vector<double>             _rewards;
+
+    inline void initializeFrames(std::size_t size);
 };
+
+
+void SequenceStorage::initializeFrames(std::size_t size)
+{
+    std::size_t frameSize = _settings.frameWidth*_settings.frameHeight
+        *getImageFormatNChannels(_settings.frameFormat);
+
+    _frames.reserve(size);
+    for (std::size_t i=0; i<size; ++i) {
+        // Initialize images with pixel data stored in _frameData
+        _frames.emplace_back(_settings.frameWidth, _settings.frameHeight, _settings.frameFormat,
+            &_frameData[i*frameSize]);
+    }
+}

--- a/include/SequenceStorage.hpp
+++ b/include/SequenceStorage.hpp
@@ -21,19 +21,28 @@ public:
     struct Settings {
         uint32_t    batchSize;
         std::size_t length;     // max sequence length
+
+        bool        hasFrames       {true};     // Does the storage contain frames?
+        bool        hasEncodings    {false};    // Does the storage contain frame encodings?
+
         uint32_t    frameWidth;
         uint32_t    frameHeight;
         ImageFormat frameFormat;
+        uint32_t    encodingLength;
     };
 
     class BatchHandle {
     public:
         gvizdoom::Action* const actions;
         Image<float>* const     frames;
+        float* const* const     encodings; // const ptr to const ptr to mutable float
         double* const           rewards;
 
         // Map pixel data to a torch tensor (BHWC)
         const torch::Tensor mapPixelData();
+
+        // Map encoding data to a torch tensor (BW)
+        const torch::Tensor mapEncodingData();
 
         friend class SequenceStorage;
 
@@ -41,11 +50,14 @@ public:
         BatchHandle(
             gvizdoom::Action* actions,
             Image<float>* frames,
+            float** encodings,
             double* rewards,
             float* frameData,
+            float* encodingData,
             const SequenceStorage::Settings& settings);
 
         float* const                        _frameData;
+        float* const                        _encodingData;
         const SequenceStorage::Settings&    _settings;
     };
 
@@ -53,6 +65,7 @@ public:
     public:
         const gvizdoom::Action* const   actions;
         const Image<float>* const       frames;
+        const float* const* const       encodings; // const ptr to const ptr to const float
         const double* const             rewards;
 
         friend class SequenceStorage;
@@ -61,6 +74,7 @@ public:
         ConstBatchHandle(
             const gvizdoom::Action* actions,
             const Image<float>* frames,
+            const float* const* encodings,
             const double* rewards);
     };
 
@@ -78,28 +92,44 @@ public:
     // Map pixel data to a torch tensor (LBHWC)
     const torch::Tensor mapPixelData();
 
+    // Map encoding data to a torch tensor (LBW)
+    const torch::Tensor mapEncodingData();
+
     const Settings& settings() const noexcept;
 
 private:
     Settings                        _settings;
-    uint64_t                        _frameSize; // size of a frame in elements
+    uint64_t                        _frameSize;     // size of a frame in elements
 
     // Sequence data vectors
     std::vector<gvizdoom::Action>   _actions;
     std::vector<Image<float>>       _frames;
-    std::vector<float>              _frameData; // pixel data storage for _frames
+    std::vector<float>              _frameData;     // pixel data storage for _frames
+    std::vector<float*>             _encodings;     // pointers to starting points of each encoding in the _encodingData vector
+    std::vector<float>              _encodingData;  // frame encodings in one long vector, similar to _frameData
     std::vector<double>             _rewards;
 
     inline void initializeFrames(std::size_t size);
+    inline void initializeEncodings(std::size_t size);
 };
 
 
 void SequenceStorage::initializeFrames(std::size_t size)
 {
+    _frames.clear();
     _frames.reserve(size);
     for (std::size_t i=0; i<size; ++i) {
         // Initialize images with pixel data stored in _frameData
         _frames.emplace_back(_settings.frameWidth, _settings.frameHeight, _settings.frameFormat,
             &_frameData[i*_frameSize]);
+    }
+}
+
+void SequenceStorage::initializeEncodings(std::size_t size)
+{
+    _encodings.resize(size);
+    for (std::size_t i=0; i<size; ++i) {
+        // point to start of each encoding in _encodingData
+        _encodings[i] = &_encodingData[i*_settings.encodingLength];
     }
 }

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -139,7 +139,8 @@ void App::loop()
             auto& entry = _sequenceStorage[recordFrameId][_batchId];
             entry.action = action;
             entry.frame = Image<uint8_t>(doomGame.getScreenWidth(), doomGame.getScreenHeight(),
-                ImageFormat::BGRA, doomGame.getPixelsBGRA());
+                ImageFormat::BGRA);
+            entry.frame.copyFrom(doomGame.getPixelsBGRA());
             entry.reward = 0.0; // TODO no rewards for now
         }
 
@@ -197,7 +198,7 @@ void App::loop()
 
             printf("Training...\n");
             _model.waitForTrainingFinish();
-            _model.trainAsync(sequenceStorageCopy);
+            _model.trainAsync(std::move(sequenceStorageCopy));
             _newPatchReady = false;
         }
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -29,7 +29,7 @@ App::App() :
     _quit                       (false),
     _heatmapActionModule        (HeatmapActionModule::Settings{256, 32.0f}),
     _doorTraversalActionModule  (),
-    _sequenceStorage            (SequenceStorage::Settings{batchSize, 64, 640, 480, ImageFormat::BGRA}),
+    _sequenceStorage            (SequenceStorage::Settings{batchSize, 64, true, false, 640, 480, ImageFormat::BGRA}),
     _positionPlot               (1024, 1024, CV_32FC3, cv::Scalar(0.0f)),
     _initPlayerPos              (0.0f, 0.0f),
     _frameId                    (0),

--- a/src/FrameDecoder.cpp
+++ b/src/FrameDecoder.cpp
@@ -51,6 +51,7 @@ torch::Tensor FrameDecoderImpl::forward(torch::Tensor x)
     using namespace torch::indexing;
 
     // Decoder
+    x = torch::reshape(x, {-1, 128, 4, 4});
     x = torch::tanh(_bnDec8(_convTranspose8(x))); // 4x4x512
     x = torch::tanh(_bnDec7(_convTranspose7(x))); // 5x5x512
     x = torch::tanh(_bnDec6(_convTranspose6(x))); // 10x10x256

--- a/src/FrameEncoder.cpp
+++ b/src/FrameEncoder.cpp
@@ -63,6 +63,7 @@ torch::Tensor FrameEncoderImpl::forward(torch::Tensor x)
     x = torch::tanh(_bnEnc6(_conv6(x))); // 5x5x512
     x = torch::tanh(_bnEnc7(_conv7(x))); // 4x4x512
     x = torch::tanh(_bnEnc8(_conv8(x))); // 4x4x128
+    x = torch::flatten(x);
 
     return x;
 }

--- a/src/ModelProto.cpp
+++ b/src/ModelProto.cpp
@@ -154,11 +154,11 @@ void ModelProto::train(const SequenceStorage& storage)
     _trainingFinished = true;
 }
 
-void ModelProto::trainAsync(const SequenceStorage& storage)
+void ModelProto::trainAsync(SequenceStorage&& storage)
 {
     if (_trainingThread.joinable())
         _trainingThread.join();
-    _trainingThread = std::thread{&ModelProto::train, this, storage};
+    _trainingThread = std::thread{&ModelProto::train, this, std::move(storage)};
 }
 
 bool ModelProto::trainingFinished() const noexcept

--- a/src/ModelProto.cpp
+++ b/src/ModelProto.cpp
@@ -55,7 +55,7 @@ ModelProto::ModelProto() :
     }
 }
 
-void ModelProto::train(const SequenceStorage& storage)
+void ModelProto::train(SequenceStorage&& storage)
 {
     // Return immediately in case there's previous training by another thread already running
     if (!_trainingFinished)
@@ -83,9 +83,7 @@ void ModelProto::train(const SequenceStorage& storage)
     for (int64_t epoch=0; epoch<nTrainingEpochs; ++epoch) {
         // ID of the frame (in sequence) to be used in the training batch
         size_t trainFrameId = epoch % storage.settings().length;
-        batchIn = torch::from_blob(
-            const_cast<float*>(storage[trainFrameId].frames->data()), // TODO very bad, create custom accessor for this
-            {batchSize, 480, 640, 4}, torch::TensorOptions().device(torch::kCPU));
+        batchIn = storage[trainFrameId].mapPixelData();
         auto* batchDataIn = batchIn.data_ptr<float>();
 
         torch::Tensor batchInGPU = batchIn.to(device);

--- a/src/SequenceStorage.cpp
+++ b/src/SequenceStorage.cpp
@@ -10,46 +10,107 @@
 
 #include "SequenceStorage.hpp"
 
+#include <cassert>
 
-SequenceStorage::Entry& SequenceStorage::BatchHandle::operator[](std::size_t id)
-{
-    return _entry[id];
-}
 
-const SequenceStorage::Entry& SequenceStorage::BatchHandle::operator[](std::size_t id) const noexcept
-{
-    return _cEntry[id];
-}
-
-SequenceStorage::BatchHandle::BatchHandle() :
-    _entry  (nullptr),
-    _cEntry (nullptr)
+SequenceStorage::BatchHandle::BatchHandle(
+    gvizdoom::Action* actions,
+    Image<float>* frames,
+    double* rewards
+) :
+    actions (actions),
+    frames  (frames),
+    rewards (rewards)
 {
 }
 
-SequenceStorage::SequenceStorage(std::size_t batchSize, std::size_t length) :
-    _batchSize      (batchSize),
-    _data           (length*_batchSize)
+SequenceStorage::ConstBatchHandle::ConstBatchHandle(
+    const gvizdoom::Action* actions,
+    const Image<float>* frames,
+    const double* rewards
+) :
+    actions (actions),
+    frames  (frames),
+    rewards (rewards)
 {
 }
 
-SequenceStorage::BatchHandle& SequenceStorage::operator[](std::size_t id)
+SequenceStorage::SequenceStorage(const Settings& settings) :
+    _settings   (settings),
+    _actions    (_settings.length*_settings.batchSize),
+    _frameData  (_settings.length*_settings.batchSize*_settings.frameWidth*_settings.frameHeight
+                 *getImageFormatNChannels(_settings.frameFormat)),
+    _rewards    (_settings.length*_settings.batchSize)
 {
-    if (_data.size() < id*_batchSize) {
-        _data.resize(id*_batchSize);
-    }
-    _batchHandle._entry = &_data[id*_batchSize];
-    return _batchHandle;
+    std::size_t size = _settings.length*_settings.batchSize;
+    initializeFrames(size);
 }
 
-const SequenceStorage::BatchHandle SequenceStorage::operator[](std::size_t id) const noexcept
+SequenceStorage::SequenceStorage(const SequenceStorage& other) :
+    _settings   (other._settings),
+    _actions    (other._actions),
+    _frameData  (other._frameData),
+    _rewards    (other._rewards)
 {
-    BatchHandle batchHandle;
-    batchHandle._cEntry = &_data.at(id*_batchSize);
-    return batchHandle;
+    initializeFrames(other._frames.size());
 }
 
-size_t SequenceStorage::size() const
+SequenceStorage::SequenceStorage(SequenceStorage&& other) noexcept :
+    _settings   (std::move(other._settings)),
+    _actions    (std::move(other._actions)),
+    _frameData  (std::move(other._frameData)),
+    _rewards    (std::move(other._rewards))
 {
-    return _data.size() / _batchSize;
+    initializeFrames(other._frames.size());
+}
+
+SequenceStorage& SequenceStorage::operator=(const SequenceStorage& other)
+{
+    _settings = other._settings;
+    _actions = other._actions;
+    _frameData = other._frameData;
+    _rewards = other._rewards;
+
+    initializeFrames(other._frames.size());
+
+    return *this;
+}
+
+SequenceStorage& SequenceStorage::operator=(SequenceStorage&& other) noexcept
+{
+    _settings = std::move(other._settings);
+    _actions = std::move(other._actions);
+    _frameData = std::move(other._frameData);
+    _rewards = std::move(other._rewards);
+
+    initializeFrames(other._frames.size());
+
+    return *this;
+}
+
+SequenceStorage::BatchHandle SequenceStorage::operator[](std::size_t id)
+{
+    assert(id < _settings.length);
+
+    return {
+        &_actions[id*_settings.batchSize],
+        &_frames[id*_settings.batchSize],
+        &_rewards[id*_settings.batchSize]
+    };
+}
+
+SequenceStorage::ConstBatchHandle SequenceStorage::operator[](std::size_t id) const noexcept
+{
+    assert(id < _settings.length);
+
+    return {
+        &_actions[id*_settings.batchSize],
+        &_frames[id*_settings.batchSize],
+        &_rewards[id*_settings.batchSize]
+    };
+}
+
+const SequenceStorage::Settings& SequenceStorage::settings() const noexcept
+{
+    return _settings;
 }


### PR DESCRIPTION
- Make `SequenceStorage` data-centric
  - Change from array-of-structs architecture to struct-of-arrays architecture
    - Sequential data layout for each member
  - Enable direct mapping to torch tensors without the need for copies
- Refactor `Image` to enable the use of an external pixel buffer
  - Allows the pixel data of subsequent frames to be stored into a continuous buffer inside the `SequenceStorage`
- Add image encodings to `SequenceStorage`
- Upload the full sequence storage pixel data before training
- Add flatten / reshape into `FrameEncoder` / `FrameDecoder`
  - So that the image encoding shape is `[ b, 2048 ]` instead of `[ b, 128, 4, 4 ]`