### PR TITLE
Constants: add a global constants header

### DIFF
--- a/include/Constants.hpp
+++ b/include/Constants.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace doot2
+{
+constexpr uint32_t encodingLength = 2048;
+constexpr uint32_t batchSize = 16;
+constexpr uint32_t actionVectorLength = 6;
+constexpr uint32_t sequenceLength = 64;
+constexpr uint32_t frameWidth = 640;
+constexpr uint32_t frameHeight = 480;
+constexpr char frameEncoderFilename[] {"models/frame_encoder.pt"};
+constexpr char frameDecoderFilename[] {"models/frame_decoder.pt"};
+constexpr char flowDecoderFilename[] {"models/flow_decoder.pt"};
+}

--- a/src/ActionManager.cpp
+++ b/src/ActionManager.cpp
@@ -9,13 +9,11 @@
 //
 
 #include "ActionManager.hpp"
+#include "Constants.hpp"
 #include "HeatmapActionModule.hpp"
 
-
+using namespace doot2;
 using namespace gvizdoom;
-
-
-static constexpr size_t actionVectorLength = 6;
 
 
 std::default_random_engine      ActionManager::_rnd       (1507715517);

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -14,12 +14,10 @@
 
 #include <opencv2/highgui.hpp>
 
+#include "Constants.hpp"
 
+using namespace doot2;
 using namespace gvizdoom;
-
-
-constexpr std::size_t batchSize = 16;
-
 
 App::App() :
     _rnd                        (1507715517),
@@ -29,7 +27,7 @@ App::App() :
     _quit                       (false),
     _heatmapActionModule        (HeatmapActionModule::Settings{256, 32.0f}),
     _doorTraversalActionModule  (false),
-    _sequenceStorage            (SequenceStorage::Settings{batchSize, 64, true, false, 640, 480, ImageFormat::BGRA}),
+    _sequenceStorage            (SequenceStorage::Settings{batchSize, sequenceLength, true, false, frameWidth, frameHeight, ImageFormat::BGRA}),
     _positionPlot               (1024, 1024, CV_32FC3, cv::Scalar(0.0f)),
     _initPlayerPos              (0.0f, 0.0f),
     _frameId                    (0),

--- a/src/ModelProto.cpp
+++ b/src/ModelProto.cpp
@@ -17,14 +17,12 @@
 #include <filesystem>
 #include <random>
 
+#include "Constants.hpp"
 
-static constexpr int        batchSize               = 16; // TODO move somewhere sensible
 static constexpr double     learningRate            = 1.0e-3; // TODO
 static constexpr int64_t    nTrainingEpochs         = 10;
-static constexpr char       frameEncoderFilename[]  {"frame_encoder.pt"};
-static constexpr char       frameDecoderFilename[]  {"frame_decoder.pt"};
-static constexpr char       flowDecoderFilename[]   {"flow_decoder.pt"};
 
+using namespace doot2;
 
 using namespace torch;
 namespace tf = torch::nn::functional;


### PR DESCRIPTION
Add a header for global constants used throughout the codebase:

- encoding length
- batch size
- actionvector length
- sequence length
- model file names