### PR TITLE
Image: Implement format conversions

### DIFF
--- a/include/Image.hpp
+++ b/include/Image.hpp
@@ -12,13 +12,18 @@
 
 
 #include "Utils.hpp"
+#include "MathTypes.hpp"
 
 #include <cstdint>
 #include <vector>
+#include <type_traits>
 
 
-enum class ImageFormat {
-    BGRA // only BGRA supported for now
+enum class ImageFormat : uint32_t {
+    BGRA_GAMMA  = 1,            // sRGB gamma correction
+    BGRA        = BGRA_GAMMA,
+    YUV         = 2,
+    UNCHANGED   = 0             // only allowed as an argument to convertImage
 };
 
 inline int getImageFormatNChannels(ImageFormat imageFormat);
@@ -43,10 +48,15 @@ public:
     // Set pixel data (will read width * height * nchannels * sizeof(T_Data) bytes from data)
     void copyFrom(const T_Data* data);
 
+    // Convert to other format
+    // Note: Only conversion to formats with equal amount of channels is permitted when
+    // using external buffer
+    void convertImageFormat(ImageFormat destFormat);
+
     template <typename T_DataOther>
     friend class Image;
     template <typename T_DataSrc, typename T_DataDest>
-    friend void convertImage(const Image<T_DataSrc>&, Image<T_DataDest>&);
+    friend void convertImage(const Image<T_DataSrc>&, Image<T_DataDest>&, ImageFormat);
 
 private:
     int                 _width;
@@ -59,11 +69,37 @@ private:
 
     template <typename T_DataOther>
     void copyParamsFrom(const Image<T_DataOther>& other);
+
+    INLINE bool usingExternalBuffer();
+
+    // Format conversion machinery
+    static void convertImageFormat(
+        ImageFormat srcFormat, ImageFormat destFormat,
+        const T_Data* srcBuffer, size_t nSrcBufferElements,
+        T_Data* destBuffer, size_t nDestBufferElements);
+    template <int T_NChannelsSrc>
+    static inline void convertImageFormat_(
+        ImageFormat srcFormat, ImageFormat destFormat,
+        const T_Data* srcBuffer, size_t nSrcBufferElements,
+        T_Data* destBuffer, size_t nDestBufferElements);
+    template <int T_NChannelsSrc, int T_NChannelsDest>
+    INLINE static void applyFormatConversion(
+        const Eigen::Matrix<T_Data, T_NChannelsDest, T_NChannelsSrc>& matrix,
+        const T_Data* srcBuffer, size_t nSrcBufferElements,
+        T_Data* destBuffer, size_t nDestBufferElements);
 };
 
 
 template <typename T_DataSrc, typename T_DataDest>
-inline void convertImage(const Image<T_DataSrc>& srcImage, Image<T_DataDest>& destImage);
+inline void convertImage(
+    const Image<T_DataSrc>& srcImage,
+    Image<T_DataDest>& destImage,
+    ImageFormat destFormat = ImageFormat::UNCHANGED);
+
+// Helper function for getting a matrix for image format conversion
+template <typename T_Data, int T_NChannelsSrc, int T_NChannelsDest>
+inline Eigen::Matrix<T_Data, T_NChannelsDest, T_NChannelsSrc>
+    getImageFormatConversionMatrix(ImageFormat srcFormat, ImageFormat destFormat);
 
 
 #include "Image.inl"

--- a/include/Image.inl
+++ b/include/Image.inl
@@ -10,14 +10,21 @@
 
 INLINE int getImageFormatNChannels(ImageFormat imageFormat)
 {
-    if (imageFormat == ImageFormat::BGRA)
-        return 4;
-
+    switch (imageFormat) {
+        case ImageFormat::BGRA:
+            return 4;
+        case ImageFormat::YUV:
+            return 3;
+        case ImageFormat::UNCHANGED:
+            return 0;
+        default:
+            return -1;
+    }
     return -1;
 }
 
 
-template<typename T_Data>
+template <typename T_Data>
 Image<T_Data>::Image(int width, int height, ImageFormat format, T_Data* data) :
     _width      (width),
     _height     (height),
@@ -25,13 +32,18 @@ Image<T_Data>::Image(int width, int height, ImageFormat format, T_Data* data) :
     _data       (data),
     _nElements  (_width*_height*getImageFormatNChannels(format))
 {
+    // Unchanged only allowed in convertImage
+    if (_format == ImageFormat::UNCHANGED)
+        throw std::runtime_error("Invalid image format");
+
+    // Using internal buffer, allocate it
     if (_data == nullptr) {
         _buffer.resize(_nElements);
         _data = _buffer.data();
     }
 }
 
-template<typename T_Data>
+template <typename T_Data>
 Image<T_Data>::Image(const Image<T_Data>& other) :
     _width      (other._width),
     _height     (other._height),
@@ -44,7 +56,7 @@ Image<T_Data>::Image(const Image<T_Data>& other) :
     memcpy(_data, other._data, _nElements*sizeof(T_Data)); // make a copy of the pixel data
 }
 
-template<typename T_Data>
+template <typename T_Data>
 Image<T_Data>& Image<T_Data>::operator=(const Image<T_Data>& other)
 {
     if (this == &other)
@@ -55,38 +67,68 @@ Image<T_Data>& Image<T_Data>::operator=(const Image<T_Data>& other)
     return *this;
 }
 
-template<typename T_Data>
+template <typename T_Data>
 int Image<T_Data>::width() const noexcept
 {
     return _width;
 }
 
-template<typename T_Data>
+template <typename T_Data>
 int Image<T_Data>::height() const noexcept
 {
     return _height;
 }
 
-template<typename T_Data>
+template <typename T_Data>
 const ImageFormat& Image<T_Data>::format() const noexcept
 {
     return _format;
 }
 
-template<typename T_Data>
+template <typename T_Data>
 const T_Data* Image<T_Data>::data() const noexcept
 {
     return _data;
 }
 
-template<typename T_Data>
+template <typename T_Data>
 void Image<T_Data>::copyFrom(const T_Data* data)
 {
     memcpy(_buffer.data(), data, _nElements * sizeof(T_Data));
 }
 
-template<typename T_Data>
-template<typename T_DataOther>
+template <typename T_Data>
+void Image<T_Data>::convertImageFormat(ImageFormat destFormat)
+{
+    if (destFormat == ImageFormat::UNCHANGED)
+        return;
+
+    if (usingExternalBuffer() && getImageFormatNChannels(destFormat) != getImageFormatNChannels(_format)) {
+        throw std::runtime_error("Number of format channels need to match when using external buffer");
+    }
+
+    // New number of elements, new buffer
+    size_t newNElements = _width*_height*getImageFormatNChannels(destFormat);
+    std::vector<T_Data> destBuffer(newNElements);
+
+    // Convert
+    convertImageFormat(_format, destFormat, _data, _nElements, destBuffer.data(), newNElements);
+
+    // Replace the old buffer
+    if (usingExternalBuffer()) {
+        memcpy(_data, destBuffer.data(), _nElements * sizeof(T_Data));
+    }
+    else {
+        _nElements = newNElements;
+        _buffer = std::move(destBuffer);
+        _data = _buffer.data();
+    }
+
+    _format = destFormat;
+}
+
+template <typename T_Data>
+template <typename T_DataOther>
 void Image<T_Data>::copyParamsFrom(const Image<T_DataOther>& other)
 {
     _width = other._width;
@@ -97,49 +139,216 @@ void Image<T_Data>::copyParamsFrom(const Image<T_DataOther>& other)
     _data = _buffer.data();
 }
 
+template <typename T_Data>
+INLINE bool Image<T_Data>::usingExternalBuffer()
+{
+    return _data != _buffer.data();
+}
+
+template <typename T_Data>
+void Image<T_Data>::convertImageFormat(
+    ImageFormat srcFormat, ImageFormat destFormat,
+    const T_Data* srcBuffer, size_t nSrcBufferElements,
+    T_Data* destBuffer, size_t nDestBufferElements
+) {
+    switch (getImageFormatNChannels(srcFormat)) {
+        case -1:
+        case 0:
+            throw std::runtime_error("Invalid image format (bug)");
+
+        case 3:
+            convertImageFormat_<3>(srcFormat, destFormat,
+                srcBuffer, nSrcBufferElements, destBuffer, nDestBufferElements);
+            break;
+
+        case 4:
+            convertImageFormat_<4>(srcFormat, destFormat,
+                srcBuffer, nSrcBufferElements, destBuffer, nDestBufferElements);
+            break;
+
+        default:
+            throw std::runtime_error("Requested format conversion not implemented yet");
+    }
+}
+
+template <typename T_Data>
+template <int T_NChannelsSrc>
+inline void Image<T_Data>::convertImageFormat_(
+    ImageFormat srcFormat, ImageFormat destFormat,
+    const T_Data* srcBuffer, size_t nSrcBufferElements,
+    T_Data* destBuffer, size_t nDestBufferElements
+) {
+    switch (getImageFormatNChannels(destFormat)) {
+    case -1:
+        throw std::runtime_error("Invalid image format (bug)");
+    case 0: // UNCHANGED, do nothing
+        return;
+    case 3: {
+        static const auto conversionMatrix =
+            getImageFormatConversionMatrix<T_Data, T_NChannelsSrc, 3>(srcFormat, destFormat);
+        applyFormatConversion<T_NChannelsSrc, 3>(conversionMatrix,
+            srcBuffer, nSrcBufferElements, destBuffer, nDestBufferElements);
+    }   return;
+    case 4: {
+        static const auto conversionMatrix =
+            getImageFormatConversionMatrix<T_Data, T_NChannelsSrc, 4>(srcFormat, destFormat);
+        applyFormatConversion<T_NChannelsSrc, 4>(conversionMatrix,
+            srcBuffer, nSrcBufferElements, destBuffer, nDestBufferElements);
+    }   return;
+    default:
+        throw std::runtime_error("Requested format conversion not implemented yet");
+    }
+}
+
+template <typename T_Data>
+template<int T_NChannelsSrc, int T_NChannelsDest>
+INLINE void Image<T_Data>::applyFormatConversion(
+    const Eigen::Matrix<T_Data, T_NChannelsDest, T_NChannelsSrc>& matrix,
+    const T_Data* srcBuffer, size_t nSrcBufferElements,
+    T_Data* destBuffer, size_t nDestBufferElements
+) {
+    using SrcPixels = Eigen::Matrix<T_Data, T_NChannelsSrc, Eigen::Dynamic>;
+    using SrcPixelsMap = Eigen::Map<const SrcPixels>;
+    using DestPixels = Eigen::Matrix<T_Data, T_NChannelsDest, Eigen::Dynamic>;
+    using DestPixelsMap = Eigen::Map<DestPixels>;
+
+    SrcPixelsMap srcPixels(srcBuffer, T_NChannelsSrc, nSrcBufferElements / T_NChannelsSrc);
+    DestPixelsMap destPixels(destBuffer, T_NChannelsDest, nDestBufferElements / T_NChannelsDest);
+    destPixels = matrix * srcPixels;
+}
+
+
 template <typename T_DataSrc, typename T_DataDest>
-INLINE void convertImage(const Image<T_DataSrc>& srcImage, Image<T_DataDest>& destImage)
-{
-    if (destImage._data == destImage._buffer.data()) {
-        destImage.copyParamsFrom(srcImage);
+struct ImageConversionParams {};
+template <> struct ImageConversionParams<uint8_t, float> {
+    static constexpr bool   prescale    {false};
+    static constexpr float  scaleRatio  {1.0f / 255.0f};
+};
+template <> struct ImageConversionParams<float, uint8_t> {
+    static constexpr bool   prescale    {true};
+    static constexpr float  scaleRatio  {255.0f};
+};
+
+
+template <typename T_DataSrc, typename T_DataDest>
+inline void convertImage(
+    const Image<T_DataSrc>& srcImage,
+    Image<T_DataDest>& destImage,
+    ImageFormat destFormat
+) {
+    T_DataDest* data = destImage._data;
+    std::vector<T_DataDest> tempBuffer;
+    if (destImage.usingExternalBuffer()) {
+        if (srcImage._width != destImage._width || srcImage._height != destImage._height) {
+            throw std::runtime_error("Image width and height need to match when using external buffer");
+        }
+
+        if (getImageFormatNChannels(srcImage._format) != getImageFormatNChannels(destImage._format)) {
+            // Allocate a temp buffer
+            tempBuffer.resize(srcImage._nElements);
+            data = tempBuffer.data();
+        }
     }
-    else if (srcImage._nElements != destImage._nElements) {
-        throw std::runtime_error("N. of buffer elements is required to match when using external pixel buffer");
+    else {
+        destImage.copyParamsFrom(srcImage);
+        data = destImage._data;
     }
 
-    for (int i=0; i<srcImage._nElements; ++i) {
-        destImage._data[i] = static_cast<T_DataDest>(srcImage._data[i]);
+    using Params = ImageConversionParams<T_DataSrc, T_DataDest>;
+
+    if constexpr (std::is_same_v<T_DataSrc, T_DataDest>) {
+        // No conversion required, only copy
+        memcpy(data, srcImage._data, srcImage._nElements * sizeof(T_DataSrc));
+    }
+    else {
+        // Perform type conversion if the types differ
+        if constexpr (ImageConversionParams<T_DataSrc, T_DataDest>::prescale) {
+            // prescale
+            for (int i = 0; i < srcImage._nElements; ++i) {
+                data[i] = static_cast<T_DataDest>(srcImage._data[i] * Params::scaleRatio);
+            }
+        } else {
+            // postscale
+            for (int i = 0; i < srcImage._nElements; ++i) {
+                data[i] = static_cast<T_DataDest>(srcImage._data[i]) * Params::scaleRatio;
+            }
+        }
+    }
+
+    // Perform the potential image format conversion
+    if (destFormat != ImageFormat::UNCHANGED) {
+        if (data == tempBuffer.data()) { // using temp buffer for conversion
+            size_t newNElements = destImage._width*destImage._height*getImageFormatNChannels(destFormat);
+            destImage.convertImageFormat(srcImage._format, destFormat, data, srcImage._nElements,
+                destImage._data, newNElements);
+        }
+        else {
+            destImage.convertImageFormat(destFormat);
+        }
     }
 }
 
-template <>
-INLINE void convertImage<uint8_t, float>(const Image<uint8_t>& srcImage, Image<float>& destImage)
-{
-    if (destImage._data == destImage._buffer.data()) {
-        destImage.copyParamsFrom(srcImage);
-    }
-    else if (srcImage._nElements != destImage._nElements) {
-        throw std::runtime_error("N. of buffer elements is required to match when using external pixel buffer");
+template <typename T_Data, int T_NChannelsSrc, int T_NChannelsDest>
+inline Eigen::Matrix<T_Data, T_NChannelsDest, T_NChannelsSrc> getImageFormatConversionMatrix(
+    ImageFormat srcFormat, ImageFormat destFormat
+) {
+    using ConversionMatrix = Eigen::Matrix<T_Data, T_NChannelsDest, T_NChannelsSrc>;
+
+    // Check that template parameter dimensions match
+    if (getImageFormatNChannels(srcFormat) != T_NChannelsSrc ||
+        getImageFormatNChannels(destFormat) != T_NChannelsDest) {
+        throw std::runtime_error("Image format conversion matrix with invalid dimensions requested");
     }
 
-    constexpr float convertRatio = 1.0f / 255.0f;
-    for (int i=0; i<srcImage._nElements; ++i) {
-        destImage._data[i] = static_cast<float>(srcImage._data[i]) * convertRatio;
-    }
-}
+    // Converting to same format (idk why, do whatever you want), just return the identity matrix
+    if (srcFormat == destFormat)
+        return ConversionMatrix::Identity();
 
-template <>
-INLINE void convertImage<float, uint8_t>(const Image<float>& srcImage, Image<uint8_t>& destImage)
-{
-    if (destImage._data == destImage._buffer.data()) {
-        destImage.copyParamsFrom(srcImage);
+    if constexpr (T_NChannelsSrc == 4) {
+        switch (srcFormat) {
+        case ImageFormat::BGRA: {
+            switch (destFormat) {
+            case ImageFormat::YUV: { // BGRA -> YUV
+                static const auto matrix = [](){
+                    ConversionMatrix matrix;
+                    matrix  <<  0.114,      0.587,      0.299,      0.0,
+                                0.436,      -0.28886,   -0.14713,   0.0,
+                                -0.10001,   -0.51499,   0.615,      0.0;
+                    return matrix;
+                }();
+                return matrix;
+            }
+            default:
+                break;
+            }
+        }   break;
+
+        default: break;
+        }
     }
-    else if (srcImage._nElements != destImage._nElements) {
-        throw std::runtime_error("N. of buffer elements is required to match when using external pixel buffer");
+    else if constexpr (T_NChannelsSrc == 3) {
+        switch (srcFormat) {
+        case ImageFormat::YUV: {
+            switch (destFormat) {
+            case ImageFormat::BGRA: { // YUV -> BGRA
+                static const auto matrix = [](){
+                    ConversionMatrix matrix;
+                    matrix  <<  0.99998,    2.03211,        -1.5082e-05,
+                                1.0,        -0.394646,      -0.580594,
+                                1.0,        -1.17892e-05,   1.13983,
+                                0.0,        0.0,            0.0;
+                    return matrix;
+                }();
+                return matrix;
+            }
+
+            default: break;
+            }
+        }   break;
+
+        default: break;
+        }
     }
 
-    constexpr float convertRatio = 255.0f;
-    for (int i=0; i<srcImage._nElements; ++i) {
-        destImage._data[i] = static_cast<uint8_t>(srcImage._data[i] * convertRatio);
-    }
+    throw std::runtime_error("Requested format conversion not implemented yet");
 }


### PR DESCRIPTION
- Complete overhaul of image format conversion functionality
- `convertImage` takes now optional `ImageFormat destFormat` argument
- Added `convertImageFormat` method that can be used to change image format (but not data type obviously) in-place
- Currently only BGRA <-> YUV supported