### PR TITLE
Pytorch integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "ext/json"]
 	path = ext/json
 	url = git@github.com:nlohmann/json.git
+[submodule "ext/pytorch"]
+	path = ext/pytorch
+	url = git@github.com:pytorch/pytorch.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,5 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.26)
 project(DooT2)
-
-
-set(CMAKE_CUDA_ARCHITECTURES 89 CACHE STRING "Supported CUDA architectures")
-set(CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc CACHE PATH "CUDA Compiler location")
-set(CUDA_TOOLKIT_ROOT_DIR /usr/local/cuda-11.8 CACHE PATH "CUDA Toolkit location")
 
 
 # Add external dependencies
@@ -13,12 +8,6 @@ add_subdirectory(ext)
 find_package(SDL2 REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(OpenCV REQUIRED)
-
-option(LIBTORCH_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../pytorch/torch")
-set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${LIBTORCH_DIR})
-set(Caffe2_DIR "${LIBTORCH_DIR}/share/cmake/Caffe2/") # ???
-include_directories("${LIBTORCH_DIR}/lib/include") # ???
-find_package(Torch REQUIRED)
 
 # Source files
 set(DOOT2_SOURCES
@@ -48,14 +37,16 @@ target_link_libraries(doot2
     PUBLIC  ${SDL2_LIBRARIES}
     PUBLIC  Eigen3::Eigen
     PUBLIC  opencv_highgui
-    PUBLIC  torch
+    PUBLIC  torch_interface
     PUBLIC  nlohmann_json
+    PUBLIC  pthread
 )
 target_compile_definitions(doot2
     PUBLIC  ASSETS_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/assets\"
 )
 set_target_properties(doot2 PROPERTIES
-    CXX_STANDARD    20
+    CXX_STANDARD        20
+    CUDA_ARCHITECTURES  native
 )
 
 
@@ -71,7 +62,8 @@ target_include_directories(doot2_tests
     PUBLIC  ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 set_target_properties(doot2_tests PROPERTIES
-    CXX_STANDARD    20
+    CXX_STANDARD        20
+    CUDA_ARCHITECTURES  native
 )
 target_link_libraries(doot2_tests
     PUBLIC  GTest::gtest_main

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -1,2 +1,59 @@
+# Direct CMake submodules
 add_subdirectory(GViZDoom)
 add_subdirectory(json)
+
+# PyTorch requires a bit of extra work:
+
+# Create build directory
+set(PYTORCH_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/pytorch)
+file(MAKE_DIRECTORY ${PYTORCH_BUILD_DIR})
+
+# Directories for find_package
+set(LIBTORCH_DIR ${CMAKE_CURRENT_SOURCE_DIR}/pytorch/torch)
+set(Caffe2_DIR "${LIBTORCH_DIR}/share/cmake/Caffe2/")
+set(Torch_DIR "${PYTORCH_BUILD_DIR}/build/")
+set(ENV{TORCH_INSTALL_PREFIX} "${PYTORCH_BUILD_DIR}/build/")
+
+# Build libtorch in case it has not been built yet
+find_package(Torch QUIET)
+if (TORCH_FOUND)
+    message(STATUS "libtorch found, skipping the build")
+else()
+    message(STATUS "Building libtorch")
+    find_package(Python3 COMPONENTS Interpreter REQUIRED)
+    execute_process(
+        COMMAND             ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/pytorch/tools/build_libtorch.py --rerun-cmake
+        WORKING_DIRECTORY   ${PYTORCH_BUILD_DIR}
+        RESULT_VARIABLE     BUILD_LIBTORCH_RETURN
+    )
+    if (NOT BUILD_LIBTORCH_RETURN EQUAL "0")
+        message(FATAL_ERROR "Unable to build libtorch")
+    endif()
+endif()
+
+# At this point libtorch should be built
+if (NOT TORCH_FOUND)
+    set(Caffe2_DIR "${LIBTORCH_DIR}/share/cmake/Caffe2/")
+    set(Torch_DIR "${PYTORCH_BUILD_DIR}/build/")
+    set(ENV{TORCH_INSTALL_PREFIX} "${PYTORCH_BUILD_DIR}/build/")
+    find_package(Torch REQUIRED)
+endif()
+
+# find_package sets the TORCH_INCLUDE_DIRS to point to build directory, correct this
+set(TORCH_INCLUDE_DIRS
+    ${LIBTORCH_DIR}/include
+    ${LIBTORCH_DIR}/include/torch/csrc/api/include
+)
+set_target_properties(torch PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES   "${TORCH_INCLUDE_DIRS}"
+)
+
+# Add interface library to enable easy usage on the main CMakeLists (no need to hassle with
+# the include directories and such)
+add_library(torch_interface INTERFACE)
+target_link_libraries(torch_interface
+    INTERFACE   torch
+)
+target_include_directories(torch_interface
+    INTERFACE   ${TORCH_INCLUDE_DIRS}
+)

--- a/ext/libtorch_build_config.cmake
+++ b/ext/libtorch_build_config.cmake
@@ -1,0 +1,6 @@
+# libtorch build config is done via environment variables
+set(ENV{BUILD_PYTHON} 0)
+set(ENV{USE_NUMPY} 0)
+set(ENV{BUILD_CAFFE2_OPS} 0)
+set(ENV{BUILD_TEST} 0)
+set(ENV{USE_CUDNN} 1)


### PR DESCRIPTION
- Add [pytorch](https://github.com/pytorch/pytorch) as a submodule, this has a couple of benefits:
  - Always the correct version that has been tested to work with the project
  - Installation happens with the other submodules, no external fiddling required
- Compile libtorch from source during the CMake configuration
  - This may take quite a while on less powerful systems, fortunately this has to be done only once