### PR TITLE
Fix models crash

### DIFF
--- a/include/Constants.hpp
+++ b/include/Constants.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <filesystem>
+
+
 namespace doot2
 {
 constexpr uint32_t encodingLength = 2048;
@@ -8,7 +11,8 @@ constexpr uint32_t actionVectorLength = 6;
 constexpr uint32_t sequenceLength = 64;
 constexpr uint32_t frameWidth = 640;
 constexpr uint32_t frameHeight = 480;
-constexpr char frameEncoderFilename[] {"models/frame_encoder.pt"};
-constexpr char frameDecoderFilename[] {"models/frame_decoder.pt"};
-constexpr char flowDecoderFilename[] {"models/flow_decoder.pt"};
+static const std::filesystem::path modelsDirectory {"models"};
+static const std::filesystem::path frameEncoderFilename {modelsDirectory / "frame_encoder.pt"};
+static const std::filesystem::path frameDecoderFilename {modelsDirectory / "frame_decoder.pt"};
+static const std::filesystem::path flowDecoderFilename {modelsDirectory / "flow_decoder.pt"};
 }

--- a/src/AutoEncoderModel.cpp
+++ b/src/AutoEncoderModel.cpp
@@ -94,35 +94,35 @@ AutoEncoderModel::AutoEncoderModel() :
 
     // Load frame encoder
     if (fs::exists(frameEncoderFilename)) {
-        printf("Loading frame encoder model from %s\n", frameEncoderFilename); // TODO logging
+        printf("Loading frame encoder model from %s\n", frameEncoderFilename.c_str()); // TODO logging
         serialize::InputArchive inputArchive;
         inputArchive.load_from(frameEncoderFilename);
         _frameEncoder->load(inputArchive);
     }
     else {
-        printf("No %s found. Initializing new frame encoder model.\n", frameEncoderFilename); // TODO logging
+        printf("No %s found. Initializing new frame encoder model.\n", frameEncoderFilename.c_str()); // TODO logging
     }
 
     // Load frame decoder
     if (fs::exists(frameDecoderFilename)) {
-        printf("Loading frame decoder model from %s\n", frameDecoderFilename); // TODO logging
+        printf("Loading frame decoder model from %s\n", frameDecoderFilename.c_str()); // TODO logging
         serialize::InputArchive inputArchive;
         inputArchive.load_from(frameDecoderFilename);
         _frameDecoder->load(inputArchive);
     }
     else {
-        printf("No %s found. Initializing new frame decoder model.\n", frameDecoderFilename); // TODO logging
+        printf("No %s found. Initializing new frame decoder model.\n", frameDecoderFilename.c_str()); // TODO logging
     }
 
     // Load flow decoder
     if (fs::exists(flowDecoderFilename)) {
-        printf("Loading frame decoder model from %s\n", flowDecoderFilename); // TODO logging
+        printf("Loading frame decoder model from %s\n", flowDecoderFilename.c_str()); // TODO logging
         serialize::InputArchive inputArchive;
         inputArchive.load_from(flowDecoderFilename);
         _flowDecoder->load(inputArchive);
     }
     else {
-        printf("No %s found. Initializing new flow decoder model.\n", flowDecoderFilename); // TODO logging
+        printf("No %s found. Initializing new flow decoder model.\n", flowDecoderFilename.c_str()); // TODO logging
     }
 }
 
@@ -431,23 +431,29 @@ void AutoEncoderModel::trainImpl(SequenceStorage& storage)
     }
 
     // Save models
+    try
     {
-        printf("Saving frame encoder model to %s\n", doot2::frameEncoderFilename);
-        serialize::OutputArchive outputArchive;
-        _frameEncoder->save(outputArchive);
-        outputArchive.save_to(doot2::frameEncoderFilename);
+        {
+            printf("Saving frame encoder model to %s\n", doot2::frameEncoderFilename.c_str());
+            serialize::OutputArchive outputArchive;
+            _frameEncoder->save(outputArchive);
+            outputArchive.save_to(doot2::frameEncoderFilename);
+        }
+        {
+            printf("Saving frame decoder model to %s\n", doot2::frameDecoderFilename.c_str());
+            serialize::OutputArchive outputArchive;
+            _frameDecoder->save(outputArchive);
+            outputArchive.save_to(doot2::frameDecoderFilename);
+        }
+        {
+            printf("Saving flow decoder model to %s\n", doot2::flowDecoderFilename.c_str());
+            serialize::OutputArchive outputArchive;
+            _flowDecoder->save(outputArchive);
+            outputArchive.save_to(doot2::flowDecoderFilename);
+        }
     }
-    {
-        printf("Saving frame decoder model to %s\n", doot2::frameDecoderFilename);
-        serialize::OutputArchive outputArchive;
-        _frameDecoder->save(outputArchive);
-        outputArchive.save_to(doot2::frameDecoderFilename);
-    }
-    {
-        printf("Saving flow decoder model to %s\n", doot2::flowDecoderFilename);
-        serialize::OutputArchive outputArchive;
-        _flowDecoder->save(outputArchive);
-        outputArchive.save_to(doot2::flowDecoderFilename);
+    catch (const std::exception& e) {
+        printf("Could not save the models: '%s'\n", e.what());
     }
 
     _trainingFinished = true;

--- a/src/Trainer.cpp
+++ b/src/Trainer.cpp
@@ -18,6 +18,7 @@
 
 
 using namespace gvizdoom;
+namespace fs = std::filesystem;
 
 
 Trainer::Trainer(Model* model, uint32_t batchSizeIn, size_t sequenceLengthIn) :
@@ -44,6 +45,14 @@ Trainer::Trainer(Model* model, uint32_t batchSizeIn, size_t sequenceLengthIn) :
     // Setup ActionManager
     _actionManager.addModule(&_doorTraversalActionModule);
     _actionManager.addModule(&_heatmapActionModule);
+
+    // Create output directories if they do not exist
+    if (not fs::exists(doot2::modelsDirectory)) {
+        printf("Default models directory does not exist. Trying to create the directory\n");
+        if (not fs::create_directories(fs::path(doot2::modelsDirectory))) {
+            printf("Could not create the directory for models. Expect a crash upon training\n");
+        }
+    }
 }
 
 Trainer::~Trainer()


### PR DESCRIPTION
Based on https://github.com/Lehdari/DooT2/pull/22

- If there are no `models/` folder inside the directory where the application is ran, the code crashes
- Fix this by creating the directory if it does not exist
- Add exception handling to file operations since they could fail in 7 different ways