### PR TITLE
TimeSeries bugfix

### DIFF
--- a/include/util/TimeSeries.hpp
+++ b/include/util/TimeSeries.hpp
@@ -122,9 +122,9 @@ private:
         template <typename T_Entry>
         Series(const T_Entry& defaultValue);
         Series(const Series& other);
-        Series(Series&& other) = default;
+        Series(Series&& other) noexcept;
         Series& operator=(const Series& other);
-        Series& operator=(Series&& other) = default;
+        Series& operator=(Series&& other) noexcept;
         ~Series();
 
         // Add entry, returns the new series vector size

--- a/include/util/TimeSeries.inl
+++ b/include/util/TimeSeries.inl
@@ -123,7 +123,7 @@ const void* TimeSeries::Series::defaultCopier() const
 {
     assert(_typeId == TimeSeries::typeId<T_Entry>());
     // copy construct a new default type
-    return new T_Entry(*static_cast<T_Entry*>(_data));
+    return new T_Entry(*static_cast<const T_Entry*>(_defaultValue));
 }
 
 template<typename T_Entry>

--- a/src/util/TimeSeries.cpp
+++ b/src/util/TimeSeries.cpp
@@ -133,6 +133,22 @@ TimeSeries::Series::Series(const TimeSeries::Series& other) :
 {
 }
 
+TimeSeries::Series::Series(TimeSeries::Series&& other) noexcept :
+    _data           (other._data),
+    _defaultValue   (other._defaultValue),
+    _typeId         (other._typeId),
+    _adder          (other._adder),
+    _deleter        (other._deleter),
+    _dataCopier     (other._dataCopier),
+    _defaultCopier  (other._defaultCopier),
+    _resizer        (other._resizer),
+    _serializer     (other._serializer)
+{
+    other._data = nullptr;
+    other._defaultValue = nullptr;
+    other._deleter = nullptr;
+}
+
 TimeSeries::Series& TimeSeries::Series::operator=(const TimeSeries::Series& other)
 {
     if (this == &other)
@@ -148,9 +164,34 @@ TimeSeries::Series& TimeSeries::Series::operator=(const TimeSeries::Series& othe
     return *this;
 }
 
+TimeSeries::Series& TimeSeries::Series::operator=(TimeSeries::Series&& other) noexcept
+{
+    if (this == &other)
+        return *this;
+
+    assert(_typeId == other._typeId);
+
+    _data           = other._data;
+    _defaultValue   = other._defaultValue;
+    _typeId         = other._typeId;
+    _adder          = other._adder;
+    _deleter        = other._deleter;
+    _dataCopier     = other._dataCopier;
+    _defaultCopier  = other._defaultCopier;
+    _resizer        = other._resizer;
+    _serializer     = other._serializer;
+
+    other._data = nullptr;
+    other._defaultValue = nullptr;
+    other._deleter = nullptr;
+
+    return *this;
+}
+
 TimeSeries::Series::~Series()
 {
-    (this->*_deleter)();
+    if (this->_deleter != nullptr)
+        (this->*_deleter)();
 }
 
 size_t TimeSeries::Series::addEntry(const void* entry)


### PR DESCRIPTION
For some reason, move constructor and move assignment operator were left unimplemented, which is an obvious bug.